### PR TITLE
Show files in UI (closes #2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ Unit tests for `reed_solomon` run without FUSE and cover round-trips, empty inpu
 
 ```
 src/
-  main.rs          — CLI (clap), thread orchestration, GUI (NofsApp stub)
+  main.rs          — CLI (clap), thread orchestration, GUI (NofsApp with file tree)
   fs.rs            — NofsFS struct implementing fuser::Filesystem, ChangelogManager, FUSE ops
   blob.rs          — Blob storage layer: read/write/CDC-chunk blobs (pure functions)
   store.rs         — Object store layer: TreeEntry/TreeObject/CommitObject structs + read/write fns
@@ -62,6 +62,8 @@ data_dir/
 - `TreeObject` — directory inode metadata + sorted `entries: Vec<TreeEntry>`; serialized as JSON, content-addressed by SHA-256
 - `CommitObject` — `parent_hash`, `root_tree_hash`, `timestamp_secs`, `next_inode`, `next_fh`; serialized as JSON, content-addressed
 - `ChangelogManager` — `okaywal::LogManager` impl; stores latest commit hash via `Arc<Mutex<Option<String>>>` shared with `init()` for post-recovery extraction
+- `FsEntry` — snapshot entry: `inode`, `name`, `file_type`, `size`
+- `FsSnapshot` — flat list of `(parent_inode, FsEntry)` pairs shared with GUI
 - `NofsFS` — main state:
   - `inode_meta: HashMap<u64, InodeMeta>`
   - `dir_entries: HashMap<(u64, String), u64>` — (parent_inode, name) → child_inode
@@ -71,11 +73,14 @@ data_dir/
   - `trees_dir`, `commits_dir`, `wal` — object store paths and WAL handle
   - `current_commit: Option<String>` — hash of latest commit
   - `dirty: bool`, `last_flush: Instant`
+  - `snapshot_tx: Arc<Mutex<FsSnapshot>>` — shared with GUI thread
 
 ### Two-thread model (default mode)
 
-- Main thread: `eframe::run_native()` — GUI event loop (shows a stub "nofs" label window)
+- Main thread: `eframe::run_native()` — GUI event loop showing a live file tree
 - Spawned thread: `fuser::mount2()` — blocking FUSE mount serving all filesystem ops
+
+**GUI ↔ FUSE communication:** `Arc<Mutex<FsSnapshot>>` shared between threads. The FUSE thread calls `publish_snapshot()` after every mutating operation, writing a flat `Vec<(parent_inode, FsEntry)>`. The GUI thread calls `try_lock()` each frame (non-blocking) to refresh its cached snapshot, then renders a recursive collapsible tree via egui `CollapsingHeader`. Repaint is requested every 500ms.
 
 **Lifecycle:** closing the GUI window calls `fusermount3 -u` to unmount; if the FUSE mount exits externally, the spawned thread calls `std::process::exit(0)`.
 

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -11,7 +11,21 @@ use std::collections::HashMap;
 use std::ffi::OsStr;
 use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+#[derive(Clone, Debug)]
+pub struct FsEntry {
+    pub inode: u64,
+    pub name: String,
+    pub file_type: FileType,
+    pub size: u64,
+}
+
+#[derive(Clone, Default, Debug)]
+pub struct FsSnapshot {
+    pub entries: Vec<(u64, FsEntry)>,
+}
 
 const TTL: Duration = Duration::from_secs(1);
 const FUSE_ROOT_INODE: u64 = 1;
@@ -160,10 +174,11 @@ pub struct NofsFS {
     lookup_cnt: HashMap<u64, u64>,
     dirty: bool,
     last_flush: Instant,
+    snapshot_tx: Arc<Mutex<FsSnapshot>>,
 }
 
 impl NofsFS {
-    pub fn new(data_dir: PathBuf) -> Self {
+    pub fn new(data_dir: PathBuf, snapshot_tx: Arc<Mutex<FsSnapshot>>) -> Self {
         let blob_dir = data_dir.join("blobs");
         let objects_dir = data_dir.join("objects");
         let trees_dir = objects_dir.join("trees");
@@ -183,6 +198,7 @@ impl NofsFS {
             lookup_cnt: HashMap::new(),
             dirty: false,
             last_flush: Instant::now(),
+            snapshot_tx,
         }
     }
 
@@ -213,6 +229,31 @@ impl NofsFS {
     fn mark_dirty(&mut self) {
         self.dirty = true;
         self.maybe_flush();
+    }
+
+    fn publish_snapshot(&self) {
+        let mut entries = Vec::with_capacity(self.dir_entries.len() + 1);
+        if let Some(m) = self.inode_meta.get(&FUSE_ROOT_INODE) {
+            entries.push((0u64, FsEntry {
+                inode: FUSE_ROOT_INODE,
+                name: "/".to_string(),
+                file_type: m.file_type,
+                size: m.size,
+            }));
+        }
+        for ((parent_ino, name), &child_ino) in &self.dir_entries {
+            if let Some(m) = self.inode_meta.get(&child_ino) {
+                entries.push((*parent_ino, FsEntry {
+                    inode: child_ino,
+                    name: name.clone(),
+                    file_type: m.file_type,
+                    size: m.size,
+                }));
+            }
+        }
+        if let Ok(mut snap) = self.snapshot_tx.lock() {
+            snap.entries = entries;
+        }
     }
 
     fn maybe_flush(&mut self) {
@@ -434,6 +475,7 @@ impl NofsFS {
         }
 
         self.dirty = true;
+        self.publish_snapshot();
     }
 }
 
@@ -455,6 +497,7 @@ impl Filesystem for NofsFS {
         self.wal = Some(wal);
         self.current_commit = latest_commit.lock().unwrap().clone();
         self.load_metadata();
+        self.publish_snapshot();
         Ok(())
     }
 
@@ -634,6 +677,7 @@ impl Filesystem for NofsFS {
         }
 
         self.mark_dirty();
+        self.publish_snapshot();
 
         match self.inode_meta.get(&ino) {
             Some(m) => {
@@ -719,6 +763,7 @@ impl Filesystem for NofsFS {
 
         *self.lookup_cnt.entry(ino).or_insert(0) += 1;
         self.mark_dirty();
+        self.publish_snapshot();
 
         let attr = self.inode_meta.get(&ino).unwrap().to_file_attr();
         reply.entry(&TTL, &attr, 0);
@@ -781,6 +826,7 @@ impl Filesystem for NofsFS {
 
         *self.lookup_cnt.entry(ino).or_insert(0) += 1;
         self.mark_dirty();
+        self.publish_snapshot();
 
         let attr = self.inode_meta.get(&ino).unwrap().to_file_attr();
         reply.entry(&TTL, &attr, 0);
@@ -822,6 +868,7 @@ impl Filesystem for NofsFS {
         }
 
         self.mark_dirty();
+        self.publish_snapshot();
         reply.ok();
     }
 
@@ -857,6 +904,7 @@ impl Filesystem for NofsFS {
         }
 
         self.mark_dirty();
+        self.publish_snapshot();
         reply.ok();
     }
 
@@ -919,6 +967,7 @@ impl Filesystem for NofsFS {
 
         *self.lookup_cnt.entry(ino).or_insert(0) += 1;
         self.mark_dirty();
+        self.publish_snapshot();
 
         let attr = self.inode_meta.get(&ino).unwrap().to_file_attr();
         reply.entry(&TTL, &attr, 0);
@@ -977,6 +1026,7 @@ impl Filesystem for NofsFS {
         }
 
         self.mark_dirty();
+        self.publish_snapshot();
         reply.ok();
     }
 
@@ -1017,6 +1067,7 @@ impl Filesystem for NofsFS {
 
         *self.lookup_cnt.entry(ino).or_insert(0) += 1;
         self.mark_dirty();
+        self.publish_snapshot();
 
         let attr = self.inode_meta.get(&ino).unwrap().to_file_attr();
         reply.entry(&TTL, &attr, 0);
@@ -1259,6 +1310,7 @@ impl Filesystem for NofsFS {
 
         *self.lookup_cnt.entry(ino).or_insert(0) += 1;
         self.mark_dirty();
+        self.publish_snapshot();
 
         let attr = self.inode_meta.get(&ino).unwrap().to_file_attr();
         reply.created(&TTL, &attr, 0, fh, 0);

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,9 +5,12 @@ mod store;
 
 use clap::Parser;
 use eframe::egui;
-use fs::NofsFS;
-use fuser::MountOption;
+use fs::{FsEntry, FsSnapshot, NofsFS};
+use fuser::{FileType, MountOption};
 use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+const FUSE_ROOT_INODE: u64 = 1;
 
 #[derive(Parser)]
 #[command(name = "nofs", about = "A FUSE filesystem with content-addressed storage")]
@@ -35,13 +38,65 @@ struct Args {
     no_ui: bool,
 }
 
-struct NofsApp;
+struct NofsApp {
+    snapshot: Arc<Mutex<FsSnapshot>>,
+    cached_tree: FsSnapshot,
+}
 
 impl eframe::App for NofsApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        if let Ok(snap) = self.snapshot.try_lock() {
+            self.cached_tree = snap.clone();
+        }
         egui::CentralPanel::default().show(ctx, |ui| {
-            ui.label("nofs");
+            egui::ScrollArea::vertical().show(ui, |ui| {
+                render_dir(ui, &self.cached_tree, FUSE_ROOT_INODE);
+            });
         });
+        ctx.request_repaint_after(std::time::Duration::from_millis(500));
+    }
+}
+
+fn children_of(snapshot: &FsSnapshot, parent_inode: u64) -> Vec<&FsEntry> {
+    let mut v: Vec<&FsEntry> = snapshot
+        .entries
+        .iter()
+        .filter(|(p, _)| *p == parent_inode)
+        .map(|(_, e)| e)
+        .collect();
+    v.sort_by(|a, b| match (a.file_type, b.file_type) {
+        (FileType::Directory, FileType::Directory) => a.name.cmp(&b.name),
+        (FileType::Directory, _) => std::cmp::Ordering::Less,
+        (_, FileType::Directory) => std::cmp::Ordering::Greater,
+        _ => a.name.cmp(&b.name),
+    });
+    v
+}
+
+fn render_dir(ui: &mut egui::Ui, snapshot: &FsSnapshot, parent_inode: u64) {
+    for entry in children_of(snapshot, parent_inode) {
+        match entry.file_type {
+            FileType::Directory => {
+                egui::CollapsingHeader::new(format!("📁 {}", entry.name))
+                    .id_salt(entry.inode)
+                    .show(ui, |ui| render_dir(ui, snapshot, entry.inode));
+            }
+            FileType::Symlink => {
+                ui.label(format!("🔗 {}", entry.name));
+            }
+            _ => {
+                ui.label(format!("📄 {} ({})", entry.name, human_size(entry.size)));
+            }
+        }
+    }
+}
+
+fn human_size(bytes: u64) -> String {
+    match bytes {
+        b if b < 1024 => format!("{} B", b),
+        b if b < 1024 * 1024 => format!("{:.1} KiB", b as f64 / 1024.0),
+        b if b < 1_073_741_824 => format!("{:.1} MiB", b as f64 / 1_048_576.0),
+        b => format!("{:.1} GiB", b as f64 / 1_073_741_824.0),
     }
 }
 
@@ -73,12 +128,14 @@ fn main() {
         options.push(MountOption::AllowOther);
     }
 
-    let fuse_fs = NofsFS::new(data_dir);
+    let shared_snapshot: Arc<Mutex<FsSnapshot>> = Arc::new(Mutex::new(FsSnapshot::default()));
+    let fuse_fs = NofsFS::new(data_dir, Arc::clone(&shared_snapshot));
 
     if args.no_ui {
         fuser::mount2(fuse_fs, &args.mountpoint, &options).expect("Failed to mount filesystem");
     } else {
         let mount_path = mountpoint.clone();
+        let snapshot_for_gui = Arc::clone(&shared_snapshot);
 
         std::thread::spawn(move || {
             fuser::mount2(fuse_fs, &mount_path, &options).expect("Failed to mount filesystem");
@@ -89,7 +146,12 @@ fn main() {
         eframe::run_native(
             "nofs",
             native_options,
-            Box::new(|_cc| Ok(Box::new(NofsApp))),
+            Box::new(move |_cc| {
+                Ok(Box::new(NofsApp {
+                    snapshot: snapshot_for_gui,
+                    cached_tree: FsSnapshot::default(),
+                }))
+            }),
         )
         .expect("Failed to run eframe");
 


### PR DESCRIPTION
Replace the placeholder NofsApp with a live egui file tree. Add
FsSnapshot/FsEntry types to fs.rs and a publish_snapshot() method that
the FUSE thread calls after every mutating operation (init, mknod,
mkdir, unlink, rmdir, symlink, rename, link, create, setattr,
flush_open_file). The GUI thread reads the Arc<Mutex<FsSnapshot>> each
frame via try_lock() and renders a collapsible tree using egui
CollapsingHeader, with directories sorted first and human-readable file
sizes.

https://claude.ai/code/session_01Tvx3qXmwrAtA4vg8HwUHT8