### PR TITLE
Time-machine snapshot browsing + recursive folder import

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,13 +8,34 @@ on:
 
 jobs:
   check:
-    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
 
       - uses: oven-sh/setup-bun@v2
 
       - uses: dtolnay/rust-toolchain@stable
+
+      - uses: swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      # Tauri's Rust crate links against system webkit2gtk on Linux.
+      - name: Install Linux system dependencies
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libxdo-dev \
+            patchelf
 
       - name: Install JS dependencies
         run: bun install

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,16 +35,18 @@ Two-process Tauri 2 desktop app (React 19 + TS frontend, Rust backend).
 The backend does not read the real filesystem directly; it serves everything through a `vfs::OverlayFS` (`vfs` crate) held in a `Mutex<VfsInner>` inside `VfsState`. The overlay is a stack of layers, resolved **top-down** (first layer that has a path wins; `OverlayFS` writes go only to layer 0):
 
 1. **live memory** (`MemoryFS`) — layer 0, the write target for dropped files.
-2. **persisted snapshots** (`Vec<VfsPath>`, newest-first) — frozen `MemoryFS` layers, each loaded from a numbered `.tar.gz`.
+2. **persisted snapshots** (`Vec<Snapshot>`, newest-first) — each `Snapshot` wraps a frozen `MemoryFS` `layer` plus metadata: its archive `number` (from the `{N:05}.tar.gz` filename) and `created_ms` (the archive file's mtime, epoch millis).
 3. **home** (`PhysicalFS` over the home dir) — read-only base layer.
 
 Flow:
-- **Drag-drop** (`add_dropped_files`): reads OS files with `std::fs::read` and writes them into the live memory layer at the currently-viewed dir (collisions overwrite). The window becomes "dirty".
-- **Persist** (`persist`): compresses the whole live memory layer into `~/.nofs/{N:05}.tar.gz` (tar + gzip via `tar`/`flate2`), freezes that layer into `persisted`, then starts a fresh empty memory layer. Each persist is a separate numbered archive, so file history is retained across layers.
-- **Startup** (`setup`): loads every `~/.nofs/*.tar.gz` back as persisted layers (newest-first) and starts an empty memory layer.
-- `list_dir` hides the `.nofs` store from the root listing and tags each entry with a `managed` flag (true when the path is served by the memory or a persisted layer, false when it comes only from home).
+- **Drag-drop** (`add_dropped_files` → `import_path`): recursively imports dropped OS files *and folders* into the live memory layer at the currently-viewed dir, preserving directory structure under `dest/<name>/…`. Symlinks (file or dir) are skipped via `symlink_metadata` (avoids following links out of the tree or into loops). Collisions overwrite; the window becomes "dirty". Note: empty dirs live in memory but do not survive persist, since `archive_memory` only tars files.
+- **Persist** (`persist`): compresses the whole live memory layer into `~/.nofs/{N:05}.tar.gz` (tar + gzip via `tar`/`flate2`), freezes that layer into `persisted` as a new `Snapshot`, then starts a fresh empty memory layer. Each persist is a separate numbered archive, so file history is retained across layers.
+- **Startup** (`setup`): loads every `~/.nofs/*.tar.gz` back as `Snapshot`s (newest-first, via `load_all_snapshots`) and starts an empty memory layer.
+- **Time-machine views**: `list_dir`, `read_file`, and `stream_file` take an optional `snapshot: Option<u32>` param. `None` = the live view (cached `root` overlay). `Some(n)` = a read-only view built per-call by `view()`/`snapshot_view()`: the persisted layers with `number <= n` stacked over the *current* home dir (no live memory, no newer snapshots). Per-call overlay construction is cheap (`VfsPath` layers are Arc-backed clones). Writes always target live memory, so snapshot views are read-only by construction.
+- `list_snapshots` returns `Vec<SnapshotInfo>` (number + created_ms, newest-first) for the history picker.
+- `list_dir` hides the `.nofs` store from the root listing and tags each entry with a `managed` flag (true when served by one of the active view's "ours" layers — memory + persisted for the live view, or the filtered persisted layers for a snapshot view — false when it comes only from home). `is_managed` takes the flat layer list that `view()` produces.
 
-Archive/numbering/overlay helpers (`archive_memory`, `load_archive`, `build_overlay`, `is_managed`, etc.) have unit tests under `#[cfg(test)]` in `lib.rs` (`cargo test`); the thin `#[tauri::command]` wrappers are not unit-tested.
+Archive/numbering/overlay/import helpers (`archive_memory`, `load_archive`, `load_all_snapshots`, `build_overlay`, `snapshot_view`, `is_managed`, `import_path`, `file_mtime_ms`, etc.) have unit tests under `#[cfg(test)]` in `lib.rs` (`cargo test`); the thin `#[tauri::command]` wrappers are not unit-tested.
 
 ## UI
 
@@ -52,7 +54,8 @@ Archive/numbering/overlay helpers (`archive_memory`, `load_archive`, `build_over
 - Files and folders rendered as tiles in a responsive CSS grid (`repeat(auto-fill, minmax(120px, 1fr))`).
 - SVG icons defined inline in `App.tsx`: `FolderIcon`, `FileIcon`, `ImageIcon`, `PdfIcon` (chosen per file extension), and `HomeIcon` (root breadcrumb).
 - **Layer indicator** — entries served by the memory/persisted layers (`managed: true`) get an accent dot badge (`.fb-tile-badge`) and a blue-tinted name (`.fb-tile-managed`); read-only home files render plain.
-- **Drag-drop & Persist** — dropping OS files onto the window adds them to the live layer (drop highlight via `.fb-dragging`); a **Persist** button (`.fb-persist`) appears in the topbar whenever the live layer is dirty. Drag-drop uses `getCurrentWebview().onDragDropEvent` from `@tauri-apps/api/webview` (enabled by default, no capability needed) and the `drop` payload carries real OS absolute paths.
+- **Drag-drop & Persist** — dropping OS files/folders onto the window adds them to the live layer (drop highlight via `.fb-dragging`); a **Persist** button (`.fb-persist`) appears in the topbar whenever the live layer is dirty *and* not viewing a snapshot. Drag-drop uses `getCurrentWebview().onDragDropEvent` from `@tauri-apps/api/webview` (enabled by default, no capability needed) and the `drop` payload carries real OS absolute paths.
+- **History / time-machine** — a `.fb-history` `<select>` in the topbar (shown once ≥1 snapshot exists) lists "Now" plus each snapshot (`#N — date`). Selecting a snapshot enters a read-only view: an amber `.fb-snapshot-banner` appears with an **Exit** button, the Persist button and drag-drop are suppressed, and `list_dir`/`read_file`/`stream_file` invokes pass the `snapshot` number. The active snapshot is mirrored in `snapshotRef` because the drag-drop effect registers once and would otherwise close over a stale value. `switchView` closes any open preview (revoking blob URLs) and falls back to root if the current dir doesn't exist in the selected view.
 - Topbar shows a clickable breadcrumb trail — each path segment navigates directly to that directory; the current segment is non-interactive.
 - Clicking a file tile opens a slide-in preview panel (`PreviewPanel` in `App.tsx`) on the right. Text shows inline (up to 64 KB via `read_file`); images and PDFs stream as blob URLs via the `stream_file` command; other binaries show a "no preview" message. The panel is resizable via a drag handle and sits side-by-side with the grid inside `.fb-content`.
 - Window uses the platform's standard title bar; no platform-specific native window customization, keeping the app cross-platform.
@@ -60,5 +63,5 @@ Archive/numbering/overlay helpers (`archive_memory`, `load_archive`, `build_over
 ## When adding a new Rust command
 
 1. Define `#[tauri::command] fn foo(...) -> Result<T, String>` in `src-tauri/src/lib.rs` (return types must be `Serialize`; map errors to `String` with `.map_err(|e| e.to_string())`). To serve files through the VFS, take `vfs: tauri::State<'_, VfsState>` and grab the overlay with `vfs.inner.lock().unwrap().root.clone()`.
-2. Register it in `generate_handler![list_dir, read_file, stream_file, add_dropped_files, persist, foo]`.
+2. Register it in `generate_handler![list_dir, read_file, stream_file, add_dropped_files, persist, list_snapshots, foo]`.
 3. If it uses a Tauri plugin API, grant the capability in `src-tauri/capabilities/default.json`. Plain `std::fs` / `std::env` needs no capability.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # nofs
 
-A minimal desktop file browser built with Tauri 2, React 19, and TypeScript.
+A minimal, cross-platform file-backup desktop app built with Tauri 2, React 19, and TypeScript.
 
-The Rust backend owns all filesystem access via `list_dir` and `read_file` commands. The frontend renders a macOS-style dark tile grid with SVG folder/file icons, a clickable breadcrumb topbar for quick navigation, and a slide-in preview panel that shows file content when you click a file tile.
+The Rust backend owns all filesystem access and serves everything through a layered virtual filesystem: a live in-memory layer stacked over frozen snapshot layers, over your read-only home directory. **Drag and drop** files or whole folders onto the window to import them into the live layer (directory structure preserved, symlinks skipped), then hit **Persist** to freeze them into a numbered `~/.nofs/{N}.tar.gz` snapshot. Because all history lives in that single `~/.nofs` store, backing up or syncing is just copying one directory between machines.
+
+The **History** picker lets you time-travel: select a past snapshot to browse the whole tree exactly as it was backed up at that point (read-only). The frontend renders a macOS-style dark tile grid with SVG folder/file icons, a clickable breadcrumb topbar, and a slide-in preview panel that shows file content when you click a file tile. Files served by your backup layers are marked with an accent badge.
 
 ## Develop
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -30,10 +30,25 @@ enum FilePreview {
 
 const PREVIEW_LIMIT: u64 = 64 * 1024;
 
+/// A frozen, persisted snapshot layer plus the metadata needed to identify it
+/// (its archive number and creation time) in the history picker.
+#[derive(Clone)]
+struct Snapshot {
+    number: u32,         // archive number, from {N:05}.tar.gz filename
+    created_ms: u64,     // archive file mtime, millis since UNIX_EPOCH
+    layer: vfs::VfsPath, // frozen MemoryFS
+}
+
+#[derive(Serialize)]
+struct SnapshotInfo {
+    number: u32,
+    created_ms: u64,
+}
+
 struct VfsInner {
-    root: vfs::VfsPath,           // current OverlayFS, used by read commands
-    memory: vfs::VfsPath,         // live MemoryFS = overlay layer 0 = write target
-    persisted: Vec<vfs::VfsPath>, // frozen snapshot layers, newest-first
+    root: vfs::VfsPath,       // current OverlayFS, used by read commands
+    memory: vfs::VfsPath,     // live MemoryFS = overlay layer 0 = write target
+    persisted: Vec<Snapshot>, // frozen snapshot layers, newest-first
 }
 
 struct VfsState {
@@ -57,17 +72,66 @@ fn is_dirty(mem: &vfs::VfsPath) -> bool {
     mem.read_dir().map(|mut it| it.next().is_some()).unwrap_or(false)
 }
 
-/// Whether `path` is served by the live memory layer or any persisted snapshot
-/// (as opposed to coming only from the read-only home filesystem).
-fn is_managed(memory: &vfs::VfsPath, persisted: &[vfs::VfsPath], path: &str) -> bool {
+/// Whether `path` is served by any of the given "ours" layers (live memory
+/// and/or persisted snapshots), as opposed to coming only from the read-only
+/// home filesystem. The caller supplies the layer set for the active view.
+fn is_managed(layers: &[vfs::VfsPath], path: &str) -> bool {
     let rel = path.trim_start_matches('/');
     if rel.is_empty() {
         return false;
     }
-    let exists = |layer: &vfs::VfsPath| {
+    layers.iter().any(|layer| {
         layer.join(rel).map(|p| p.exists().unwrap_or(false)).unwrap_or(false)
-    };
-    exists(memory) || persisted.iter().any(exists)
+    })
+}
+
+/// Epoch-millis mtime of a file, or 0 if it cannot be determined.
+fn file_mtime_ms(path: &Path) -> u64 {
+    std::fs::metadata(path)
+        .and_then(|m| m.modified())
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Build the read overlay and the "managed" layer set for a given view.
+///
+/// `None` is the live view: the cached root overlay, with memory + every
+/// persisted layer counting as managed. `Some(n)` is a read-only time-machine
+/// view: persisted layers with number <= n stacked over the current home dir
+/// (no live memory, no newer snapshots); only those layers count as managed.
+fn view(
+    inner: &VfsInner,
+    home: &vfs::VfsPath,
+    snapshot: Option<u32>,
+) -> (vfs::VfsPath, Vec<vfs::VfsPath>) {
+    match snapshot {
+        None => {
+            let mut managed = vec![inner.memory.clone()];
+            managed.extend(inner.persisted.iter().map(|s| s.layer.clone()));
+            (inner.root.clone(), managed)
+        }
+        Some(n) => snapshot_view(&inner.persisted, home, n),
+    }
+}
+
+/// The `Some(n)` arm of [`view`], factored out so it is unit-testable without a
+/// Tauri app handle. Returns the read-only overlay (persisted layers <= n over
+/// home) and the managed layer set (just those persisted layers).
+fn snapshot_view(
+    persisted: &[Snapshot],
+    home: &vfs::VfsPath,
+    n: u32,
+) -> (vfs::VfsPath, Vec<vfs::VfsPath>) {
+    let managed: Vec<vfs::VfsPath> = persisted
+        .iter()
+        .filter(|s| s.number <= n)
+        .map(|s| s.layer.clone())
+        .collect();
+    let mut layers = managed.clone();
+    layers.push(home.clone());
+    (vfs::VfsPath::new(vfs::OverlayFS::new(&layers)), managed)
 }
 
 fn vfs_resolve(root: &vfs::VfsPath, path: &str) -> Result<vfs::VfsPath, String> {
@@ -162,19 +226,30 @@ fn next_layer_number(dir: &Path) -> u32 {
     archive_numbers(dir).into_iter().max().unwrap_or(0) + 1
 }
 
-/// Load all persisted archives as layers, newest-first.
-fn load_all_archives(dir: &Path) -> Vec<vfs::VfsPath> {
+/// Load all persisted archives as snapshot layers, newest-first.
+fn load_all_snapshots(dir: &Path) -> Vec<Snapshot> {
     let mut nums = archive_numbers(dir);
     nums.sort_unstable_by(|a, b| b.cmp(a));
     nums.into_iter()
-        .filter_map(|n| load_archive(&dir.join(format!("{n:05}.tar.gz"))).ok())
+        .filter_map(|n| {
+            let path = dir.join(format!("{n:05}.tar.gz"));
+            let layer = load_archive(&path).ok()?;
+            Some(Snapshot { number: n, created_ms: file_mtime_ms(&path), layer })
+        })
         .collect()
 }
 
 #[tauri::command]
-fn stream_file(path: String, vfs: tauri::State<'_, VfsState>) -> Result<Response, String> {
+fn stream_file(
+    path: String,
+    snapshot: Option<u32>,
+    vfs: tauri::State<'_, VfsState>,
+) -> Result<Response, String> {
     use std::io::Read;
-    let root = vfs.inner.lock().unwrap().root.clone();
+    let root = {
+        let inner = vfs.inner.lock().unwrap();
+        view(&inner, &vfs.home, snapshot).0
+    };
     let vfs_path = vfs_resolve(&root, &path)?;
     let mut file = vfs_path.open_file().map_err(|e| e.to_string())?;
     let mut bytes = Vec::new();
@@ -183,9 +258,16 @@ fn stream_file(path: String, vfs: tauri::State<'_, VfsState>) -> Result<Response
 }
 
 #[tauri::command]
-fn read_file(path: String, vfs: tauri::State<'_, VfsState>) -> Result<FilePreview, String> {
+fn read_file(
+    path: String,
+    snapshot: Option<u32>,
+    vfs: tauri::State<'_, VfsState>,
+) -> Result<FilePreview, String> {
     use std::io::Read;
-    let root = vfs.inner.lock().unwrap().root.clone();
+    let root = {
+        let inner = vfs.inner.lock().unwrap();
+        view(&inner, &vfs.home, snapshot).0
+    };
     let vfs_path = vfs_resolve(&root, &path)?;
     let meta = vfs_path.metadata().map_err(|e| e.to_string())?;
     let file = vfs_path.open_file().map_err(|e| e.to_string())?;
@@ -199,10 +281,14 @@ fn read_file(path: String, vfs: tauri::State<'_, VfsState>) -> Result<FilePrevie
 }
 
 #[tauri::command]
-fn list_dir(path: Option<String>, vfs: tauri::State<'_, VfsState>) -> Result<Listing, String> {
-    let (root, memory, persisted) = {
+fn list_dir(
+    path: Option<String>,
+    snapshot: Option<u32>,
+    vfs: tauri::State<'_, VfsState>,
+) -> Result<Listing, String> {
+    let (root, managed) = {
         let inner = vfs.inner.lock().unwrap();
-        (inner.root.clone(), inner.memory.clone(), inner.persisted.clone())
+        view(&inner, &vfs.home, snapshot)
     };
     let dir = match path {
         Some(p) => vfs_resolve(&root, &p)?,
@@ -218,7 +304,7 @@ fn list_dir(path: Option<String>, vfs: tauri::State<'_, VfsState>) -> Result<Lis
             let path = child.as_str().to_string();
             Some(DirEntry {
                 name: child.filename(),
-                managed: is_managed(&memory, &persisted, &path),
+                managed: is_managed(&managed, &path),
                 path,
                 is_dir: meta.file_type == vfs::VfsFileType::Directory,
             })
@@ -244,34 +330,59 @@ fn list_dir(path: Option<String>, vfs: tauri::State<'_, VfsState>) -> Result<Lis
     })
 }
 
-/// Read dropped OS files and write them into the live memory layer.
-#[tauri::command]
-fn add_dropped_files(
-    dest_dir: String,
-    paths: Vec<String>,
-    vfs: tauri::State<'_, VfsState>,
-) -> Result<bool, String> {
+/// Recursively import an OS file or directory into the live `memory` layer under
+/// `base` (a VFS-relative dir, no leading slash). Directory structure is
+/// preserved beneath `base/<name>`; symlinks (to files or dirs) are skipped
+/// entirely, which also prevents following links out of the tree or into loops.
+fn import_path(memory: &vfs::VfsPath, base: &str, os_path: &Path) -> Result<(), String> {
     use std::io::Write;
-    let memory = vfs.inner.lock().unwrap().memory.clone();
-    let base = dest_dir.trim_start_matches('/');
-    for p in &paths {
-        let os_path = Path::new(p);
-        let filename = match os_path.file_name() {
-            Some(f) => f.to_string_lossy().to_string(),
-            None => continue,
-        };
-        let bytes = std::fs::read(os_path).map_err(|e| format!("{p}: {e}"))?;
-        let rel = if base.is_empty() {
-            filename
-        } else {
-            format!("{base}/{filename}")
-        };
+    let meta = std::fs::symlink_metadata(os_path)
+        .map_err(|e| format!("{}: {e}", os_path.display()))?;
+    if meta.file_type().is_symlink() {
+        return Ok(());
+    }
+    let name = match os_path.file_name() {
+        Some(f) => f.to_string_lossy().into_owned(),
+        None => return Ok(()),
+    };
+    let rel = if base.is_empty() {
+        name
+    } else {
+        format!("{base}/{name}")
+    };
+    if meta.is_dir() {
+        memory
+            .join(&rel)
+            .map_err(|e| e.to_string())?
+            .create_dir_all()
+            .map_err(|e| format!("{rel}: {e}"))?;
+        for entry in std::fs::read_dir(os_path).map_err(|e| format!("{}: {e}", os_path.display()))? {
+            let entry = entry.map_err(|e| e.to_string())?;
+            import_path(memory, &rel, &entry.path())?;
+        }
+    } else {
+        let bytes = std::fs::read(os_path).map_err(|e| format!("{}: {e}", os_path.display()))?;
         let dest = memory.join(&rel).map_err(|e| e.to_string())?;
         dest.parent().create_dir_all().map_err(|e| e.to_string())?;
         dest.create_file()
             .map_err(|e| e.to_string())?
             .write_all(&bytes)
             .map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+/// Read dropped OS files/folders and write them into the live memory layer.
+#[tauri::command]
+fn add_dropped_files(
+    dest_dir: String,
+    paths: Vec<String>,
+    vfs: tauri::State<'_, VfsState>,
+) -> Result<bool, String> {
+    let memory = vfs.inner.lock().unwrap().memory.clone();
+    let base = dest_dir.trim_start_matches('/');
+    for p in &paths {
+        import_path(&memory, base, Path::new(p))?;
     }
     Ok(is_dirty(&memory))
 }
@@ -288,10 +399,25 @@ fn persist(vfs: tauri::State<'_, VfsState>) -> Result<bool, String> {
     archive_memory(&inner.memory, &out)?;
 
     let frozen = inner.memory.clone();
-    inner.persisted.insert(0, frozen);
+    inner.persisted.insert(
+        0,
+        Snapshot { number: n, created_ms: file_mtime_ms(&out), layer: frozen },
+    );
     inner.memory = vfs::VfsPath::new(vfs::MemoryFS::new());
-    inner.root = build_overlay(&inner.memory, &inner.persisted, &vfs.home);
+    let layers: Vec<vfs::VfsPath> = inner.persisted.iter().map(|s| s.layer.clone()).collect();
+    inner.root = build_overlay(&inner.memory, &layers, &vfs.home);
     Ok(false)
+}
+
+/// List persisted snapshots, newest-first, for the history picker.
+#[tauri::command]
+fn list_snapshots(vfs: tauri::State<'_, VfsState>) -> Result<Vec<SnapshotInfo>, String> {
+    let inner = vfs.inner.lock().unwrap();
+    Ok(inner
+        .persisted
+        .iter()
+        .map(|s| SnapshotInfo { number: s.number, created_ms: s.created_ms })
+        .collect())
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -303,7 +429,8 @@ pub fn run() {
             read_file,
             stream_file,
             add_dropped_files,
-            persist
+            persist,
+            list_snapshots
         ])
         .setup(|app| {
             let home = app.path().home_dir()?;
@@ -311,9 +438,10 @@ pub fn run() {
             std::fs::create_dir_all(&persist_dir)?;
 
             let home_fs = vfs::VfsPath::new(vfs::PhysicalFS::new(&home));
-            let persisted = load_all_archives(&persist_dir);
+            let persisted = load_all_snapshots(&persist_dir);
             let memory = vfs::VfsPath::new(vfs::MemoryFS::new());
-            let root = build_overlay(&memory, &persisted, &home_fs);
+            let layers: Vec<vfs::VfsPath> = persisted.iter().map(|s| s.layer.clone()).collect();
+            let root = build_overlay(&memory, &layers, &home_fs);
 
             app.manage(VfsState {
                 inner: Mutex::new(VfsInner { root, memory, persisted }),
@@ -406,7 +534,7 @@ mod tests {
     }
 
     #[test]
-    fn load_all_archives_orders_newest_first() {
+    fn load_all_snapshots_orders_newest_first() {
         let dir = tempfile::tempdir().unwrap();
         let first = mem();
         write(&first, "f.txt", "first");
@@ -415,9 +543,141 @@ mod tests {
         write(&second, "f.txt", "second");
         archive_memory(&second, &dir.path().join("00002.tar.gz")).unwrap();
 
-        let layers = load_all_archives(dir.path());
-        assert_eq!(layers.len(), 2);
-        assert_eq!(read(&layers[0], "f.txt"), "second");
-        assert_eq!(read(&layers[1], "f.txt"), "first");
+        let snaps = load_all_snapshots(dir.path());
+        assert_eq!(snaps.len(), 2);
+        assert_eq!(snaps[0].number, 2);
+        assert_eq!(snaps[1].number, 1);
+        assert_eq!(read(&snaps[0].layer, "f.txt"), "second");
+        assert_eq!(read(&snaps[1].layer, "f.txt"), "first");
+        assert!(snaps[0].created_ms > 0);
+    }
+
+    fn snapshot(number: u32, layer: vfs::VfsPath) -> Snapshot {
+        Snapshot { number, created_ms: 0, layer }
+    }
+
+    #[test]
+    fn import_path_recurses_directories() {
+        let src = tempfile::tempdir().unwrap();
+        std::fs::write(src.path().join("a.txt"), b"alpha").unwrap();
+        std::fs::create_dir(src.path().join("sub")).unwrap();
+        std::fs::write(src.path().join("sub/b.txt"), b"bravo").unwrap();
+
+        let m = mem();
+        import_path(&m, "dest", src.path()).unwrap();
+
+        let root = src.path().file_name().unwrap().to_string_lossy().to_string();
+        assert_eq!(read(&m, &format!("dest/{root}/a.txt")), "alpha");
+        assert_eq!(read(&m, &format!("dest/{root}/sub/b.txt")), "bravo");
+    }
+
+    #[test]
+    fn import_path_imports_single_file_at_root_base() {
+        let src = tempfile::tempdir().unwrap();
+        let file = src.path().join("only.txt");
+        std::fs::write(&file, b"solo").unwrap();
+
+        let m = mem();
+        import_path(&m, "", &file).unwrap();
+        assert_eq!(read(&m, "only.txt"), "solo");
+    }
+
+    #[test]
+    fn import_path_preserves_empty_dirs_in_memory() {
+        let src = tempfile::tempdir().unwrap();
+        std::fs::create_dir(src.path().join("empty")).unwrap();
+
+        let m = mem();
+        import_path(&m, "", src.path()).unwrap();
+        let root = src.path().file_name().unwrap().to_string_lossy().to_string();
+        let dir = m.join(&format!("{root}/empty")).unwrap();
+        assert!(dir.exists().unwrap());
+        assert!(dir.is_dir().unwrap());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn import_path_skips_symlinks() {
+        let src = tempfile::tempdir().unwrap();
+        std::fs::write(src.path().join("real.txt"), b"real").unwrap();
+        std::fs::create_dir(src.path().join("realdir")).unwrap();
+        std::fs::write(src.path().join("realdir/inner.txt"), b"inner").unwrap();
+        std::os::unix::fs::symlink(src.path().join("real.txt"), src.path().join("link.txt")).unwrap();
+        std::os::unix::fs::symlink(src.path().join("realdir"), src.path().join("linkdir")).unwrap();
+
+        let m = mem();
+        import_path(&m, "", src.path()).unwrap();
+        let root = src.path().file_name().unwrap().to_string_lossy().to_string();
+
+        assert!(m.join(&format!("{root}/real.txt")).unwrap().exists().unwrap());
+        assert!(m.join(&format!("{root}/realdir/inner.txt")).unwrap().exists().unwrap());
+        assert!(!m.join(&format!("{root}/link.txt")).unwrap().exists().unwrap());
+        assert!(!m.join(&format!("{root}/linkdir")).unwrap().exists().unwrap());
+    }
+
+    #[test]
+    fn import_path_errors_when_dir_collides_with_memory_file() {
+        let src = tempfile::tempdir().unwrap();
+        let clash = src.path().join("x");
+        std::fs::create_dir(&clash).unwrap();
+
+        let m = mem();
+        write(&m, "x", "i am a file");
+        assert!(import_path(&m, "", &clash).is_err());
+    }
+
+    #[test]
+    fn snapshot_view_filters_layers_by_number() {
+        let home = mem();
+        write(&home, "shared.txt", "home");
+
+        let l1 = mem();
+        write(&l1, "shared.txt", "one");
+        let l2 = mem();
+        write(&l2, "shared.txt", "two");
+        let l3 = mem();
+        write(&l3, "shared.txt", "three");
+        // newest-first, as stored in VfsInner.persisted
+        let persisted = vec![snapshot(3, l3), snapshot(2, l2), snapshot(1, l1)];
+
+        // n between snapshot numbers resolves to the newest layer <= n
+        let (root, managed) = snapshot_view(&persisted, &home, 2);
+        assert_eq!(read(&root, "shared.txt"), "two");
+        assert_eq!(managed.len(), 2);
+
+        // n below the lowest number falls through to home; nothing managed
+        let (root, managed) = snapshot_view(&persisted, &home, 0);
+        assert_eq!(read(&root, "shared.txt"), "home");
+        assert!(managed.is_empty());
+    }
+
+    #[test]
+    fn is_managed_with_flat_layers() {
+        let a = mem();
+        write(&a, "in_a.txt", "1");
+        let b = mem();
+        write(&b, "in_b.txt", "2");
+        let layers = [a, b];
+
+        assert!(is_managed(&layers, "/in_a.txt"));
+        assert!(is_managed(&layers, "/in_b.txt"));
+        assert!(!is_managed(&layers, "/elsewhere.txt"));
+        assert!(!is_managed(&layers, "/"));
+    }
+
+    #[test]
+    fn file_mtime_ms_is_recent_for_written_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("f.txt");
+        std::fs::write(&path, b"hi").unwrap();
+
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64;
+        let mtime = file_mtime_ms(&path);
+        assert!(mtime > 0);
+        // within a generous window either side of "now"
+        assert!(now.abs_diff(mtime) < 60_000);
     }
 }

--- a/src/App.css
+++ b/src/App.css
@@ -65,6 +65,50 @@ body {
   outline-offset: -4px;
 }
 
+.fb-history {
+  flex-shrink: 0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.85em;
+  color: #f0f0f0;
+  background-color: #3a3a3c;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 5px;
+  padding: 3px 6px;
+  cursor: pointer;
+}
+
+.fb-snapshot-banner {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 6px 12px;
+  background-color: rgba(255, 184, 74, 0.12);
+  color: #ffb864;
+  border-bottom: 1px solid rgba(255, 184, 74, 0.25);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.85em;
+}
+
+.fb-snapshot-banner span {
+  flex: 1;
+}
+
+.fb-snapshot-exit {
+  flex-shrink: 0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 1em;
+  color: #ffb864;
+  background: transparent;
+  border: 1px solid rgba(255, 184, 74, 0.5);
+  border-radius: 5px;
+  padding: 2px 10px;
+  cursor: pointer;
+}
+
+.fb-snapshot-exit:hover {
+  background-color: rgba(255, 184, 74, 0.15);
+}
+
 .fb-breadcrumbs {
   display: flex;
   align-items: center;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,18 @@ type FilePreview =
   | { kind: "Image"; url: string }
   | { kind: "Pdf"; url: string };
 
+type SnapshotInfo = {
+  number: number;
+  created_ms: number;
+};
+
+function formatSnapshotDate(ms: number): string {
+  if (!ms) return "unknown date";
+  return new Date(ms).toLocaleString(undefined, {
+    year: "numeric", month: "short", day: "numeric", hour: "2-digit", minute: "2-digit",
+  });
+}
+
 const MIME_BY_EXT: Record<string, string> = {
   png: "image/png", jpg: "image/jpeg", jpeg: "image/jpeg", gif: "image/gif",
   svg: "image/svg+xml", webp: "image/webp", bmp: "image/bmp", ico: "image/x-icon",
@@ -34,8 +46,8 @@ function mediaMime(name: string): string | null {
   return MIME_BY_EXT[name.slice(dot + 1).toLowerCase()] ?? null;
 }
 
-async function streamFileToUrl(path: string, mime: string): Promise<string> {
-  const bytes = await invoke<ArrayBuffer>("stream_file", { path });
+async function streamFileToUrl(path: string, mime: string, snapshot: number | null): Promise<string> {
+  const bytes = await invoke<ArrayBuffer>("stream_file", { path, snapshot });
   const blob = new Blob([bytes], { type: mime });
   return URL.createObjectURL(blob);
 }
@@ -186,8 +198,13 @@ function App() {
   const [previewWidth, setPreviewWidth] = useState(320);
   const [dirty, setDirty] = useState(false);
   const [dragging, setDragging] = useState(false);
+  const [snapshots, setSnapshots] = useState<SnapshotInfo[]>([]);
+  const [snapshot, setSnapshot] = useState<number | null>(null);
   const resizeRef = useRef<{ startX: number; startWidth: number } | null>(null);
   const pathRef = useRef<string | null>(null);
+  // Mirrors `snapshot` for the drag-drop effect, whose listener is registered
+  // once (empty deps) and would otherwise close over a stale value.
+  const snapshotRef = useRef<number | null>(null);
 
   function onResizeStart(e: React.MouseEvent) {
     resizeRef.current = { startX: e.clientX, startWidth: previewWidth };
@@ -214,10 +231,18 @@ function App() {
 
   async function loadDir(path: string | null) {
     try {
-      const result = await invoke<Listing>("list_dir", { path });
+      const result = await invoke<Listing>("list_dir", { path, snapshot: snapshotRef.current });
       setListing(result);
       pathRef.current = result.path;
       setError(null);
+    } catch (e) {
+      setError(String(e));
+    }
+  }
+
+  async function loadSnapshots() {
+    try {
+      setSnapshots(await invoke<SnapshotInfo[]>("list_snapshots"));
     } catch (e) {
       setError(String(e));
     }
@@ -227,9 +252,26 @@ function App() {
     try {
       const d = await invoke<boolean>("persist");
       setDirty(d);
+      await loadSnapshots();
       await loadDir(pathRef.current);
     } catch (e) {
       setError(String(e));
+    }
+  }
+
+  // Switch between the live view (null) and a read-only snapshot view (number).
+  async function switchView(n: number | null) {
+    closePreview();
+    snapshotRef.current = n;
+    setSnapshot(n);
+    try {
+      const result = await invoke<Listing>("list_dir", { path: pathRef.current, snapshot: n });
+      setListing(result);
+      pathRef.current = result.path;
+      setError(null);
+    } catch {
+      // Current dir may not exist in this view — fall back to root.
+      await loadDir(null);
     }
   }
 
@@ -239,15 +281,16 @@ function App() {
     }
     setPreview({ entry, preview: null, error: null });
     try {
+      const snap = snapshotRef.current;
       const mime = mediaMime(entry.name);
       if (mime && mime.startsWith("image/")) {
-        const url = await streamFileToUrl(entry.path, mime);
+        const url = await streamFileToUrl(entry.path, mime, snap);
         setPreview({ entry, preview: { kind: "Image", url }, error: null });
       } else if (mime === "application/pdf") {
-        const url = await streamFileToUrl(entry.path, mime);
+        const url = await streamFileToUrl(entry.path, mime, snap);
         setPreview({ entry, preview: { kind: "Pdf", url }, error: null });
       } else {
-        const result = await invoke<FilePreview>("read_file", { path: entry.path });
+        const result = await invoke<FilePreview>("read_file", { path: entry.path, snapshot: snap });
         setPreview({ entry, preview: result, error: null });
       }
     } catch (e) {
@@ -264,11 +307,17 @@ function App() {
 
   useEffect(() => {
     loadDir(null);
+    loadSnapshots();
   }, []);
 
   useEffect(() => {
     const unlisten = getCurrentWebview().onDragDropEvent(async (event) => {
       const p = event.payload;
+      // Snapshot views are read-only: ignore drops and the drag highlight.
+      if (snapshotRef.current !== null) {
+        setDragging(false);
+        return;
+      }
       if (p.type === "over" || p.type === "enter") {
         setDragging(true);
       } else if (p.type === "leave") {
@@ -323,10 +372,34 @@ function App() {
                 ))
             : null}
         </nav>
-        {dirty && (
+        {snapshots.length > 0 && (
+          <select
+            className="fb-history"
+            value={snapshot ?? ""}
+            onChange={(e) => switchView(e.target.value === "" ? null : Number(e.target.value))}
+          >
+            <option value="">Now</option>
+            {snapshots.map((s) => (
+              <option key={s.number} value={s.number}>
+                #{s.number} — {formatSnapshotDate(s.created_ms)}
+              </option>
+            ))}
+          </select>
+        )}
+        {dirty && snapshot === null && (
           <button className="fb-persist" onClick={onPersist}>Persist</button>
         )}
       </header>
+
+      {snapshot !== null && (
+        <div className="fb-snapshot-banner">
+          <span>
+            Viewing snapshot #{snapshot} —{" "}
+            {formatSnapshotDate(snapshots.find((s) => s.number === snapshot)?.created_ms ?? 0)} · read-only
+          </span>
+          <button className="fb-snapshot-exit" onClick={() => switchView(null)}>Exit</button>
+        </div>
+      )}
 
       {error && <div className="fb-error">{error}</div>}
 


### PR DESCRIPTION
## What & why

Finishes nofs as a simple, cross-platform file-backup app by filling the two biggest gaps against the stated goal (full history + easy drag-drop import into a single, syncable store):

- **Time-machine snapshot browsing** — you can now browse the whole tree as it looked at any past persist point, read-only.
- **Recursive folder drag-drop** — dropping a directory now imports its whole structure, not just top-level files (previously `std::fs::read` errored on dirs).

## Changes

**Backend (`src-tauri/src/lib.rs`)**
- Persisted layers are now a `Snapshot { number, created_ms, layer }` struct instead of a bare `Vec<VfsPath>`; `created_ms` comes from the archive file's mtime (`file_mtime_ms`). New `list_snapshots` command returns them newest-first for the picker.
- `list_dir`/`read_file`/`stream_file` gained an optional `snapshot: Option<u32>` param. `None` = live view (cached overlay). `Some(n)` = read-only overlay built per call by `view()`/`snapshot_view()`: persisted layers with `number <= n` stacked over the *current* home dir (no live memory, no newer snapshots). Overlays are cheap to build (Arc-backed layer clones), so the view is stateless — no invalidation logic. Writes always target live memory, so snapshot views are read-only by construction.
- `is_managed` simplified to take the flat layer list `view()` produces.
- New recursive `import_path` helper: preserves directory structure under `dest/<name>/…`, skips symlinks (file or dir) via `symlink_metadata` to avoid escaping the tree or following loops. `add_dropped_files` now delegates to it.

**Frontend (`src/App.tsx`, `src/App.css`)**
- History `<select>` in the topbar (Now + `#N — date`), read-only amber banner with an Exit button, Persist button and drag-drop suppressed while viewing a snapshot. Active snapshot is mirrored in `snapshotRef` so the once-registered drag-drop listener doesn't close over a stale value.

**CI (`.github/workflows/ci.yml`)**
- Build matrix across Linux/macOS/Windows (`fail-fast: false`) to actually verify cross-platform builds, with the webkit2gtk/gtk system deps Tauri needs on Linux and a Rust build cache.

**Docs** — CLAUDE.md and README updated for the snapshot model, folder import, and the new command.

## Reviewer notes
- Explicitly out of scope (product decision): export/restore-to-disk, delete, configurable store location, dedup/streaming rewrites.
- Snapshot semantics: snapshot layers are stacked over *today's* home dir (home can't be rewound), so historical imports are accurate while home files shown are current.
- Known/accepted: empty dirs live in memory but don't survive persist (`archive_memory` only tars files); a mid-drop error aborts remaining items but keeps already-imported ones (matches prior per-file behavior).

## Verification
- `cargo test` — 14 pass (8 new + 1 updated, incl. `#[cfg(unix)]` symlink-skip test); `cargo check` clean, no warnings.
- `bun run build` — tsc + Vite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)